### PR TITLE
Added option to stop messages being shown all the time (default behaviour unchanged)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ list (e.g. by invoking `:lopen` or `:ll`). See more about location using
 `:help location-list` or see the 
 [online documention](http://vimdoc.sourceforge.net/htmldoc/quickfix.html).
 
+By default, any messages are shown when a file is loaded or saved. If you want
+to only show messages when you open the location list, set the following in your
+`.vimrc` file:
+
+    let g:reek_always_show = 0
+
 ### Installation
 
 Place the `plugin/reek.vim` file in your `.vim/plugin` directory.

--- a/plugin/reek.vim
+++ b/plugin/reek.vim
@@ -9,6 +9,10 @@ endif
 
 let g:loaded_reek = 1
 
+if !exists('g:reek_always_show')
+  let g:reek_always_show = 1
+endif
+
 if !exists('g:reek_debug')
   let g:reek_debug = 0
 endif
@@ -34,7 +38,9 @@ function! s:Reek()
   call setloclist(0, loclist)
   if len(loclist) > 0
     exec has("gui_running") ? "redraw!" : "redraw"
-    ll
+    if g:reek_always_show
+      ll
+    endif
   endif
 endfunction
 


### PR DESCRIPTION
I added a `g:reek_always_show` variable that when set to 0 will stop messages being shown on loads/reloads. The default behaviour is still to show the messages (as it was before this change).

When I'm working on other people's code, I'm not going to be able to get rid of all the warnings, so I like to be able to ignore them until I can do something about it.
