### PR TITLE
Add optional line limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,27 @@ list (e.g. by invoking `:lopen` or `:ll`). See more about location using
 `:help location-list` or see the 
 [online documention](http://vimdoc.sourceforge.net/htmldoc/quickfix.html).
 
+### Configuration
+
+#### Always Show
+
 By default, any messages are shown when a file is loaded or saved. If you want
 to only show messages when you open the location list, set the following in your
 `.vimrc` file:
 
     let g:reek_always_show = 0
+
+By default, messages are always shown.
+
+#### Line Limit
+
+Checking large files (> 1000 lines) can take a while.
+To load larger files quicker, you can limit maximum number of lines a file can
+have and still be checked. Files bigger than this limit will not be checked:
+
+    let g:reek_line_limit = 1000
+
+With no line limit set, all files will be checked.
 
 ### Installation
 

--- a/plugin/reek.vim
+++ b/plugin/reek.vim
@@ -18,6 +18,12 @@ if !exists('g:reek_debug')
 endif
 
 function! s:Reek()
+  if exists('g:reek_line_limit')
+    if line('$') > g:reek_line_limit
+      return
+    endif
+  endif
+
   let metrics = system("reek -n " . expand("%:p"))
   let loclist = []
   let bufnr = bufnr('%')


### PR DESCRIPTION
Add another optional parameter `g:reek_line_limit`, which will stop running `reek` if a file is over the limit - checking 6000 line files can take a little while, and I like my Vim to start fast!

Readme updated with configuration section.

Thanks for the plugin!
