### PR TITLE
Line numbers in reek >= 1.3.4 are shown by default

### DIFF
--- a/plugin/reek.vim
+++ b/plugin/reek.vim
@@ -24,7 +24,7 @@ function! s:Reek()
     return
   endif
 
-  let metrics = system("reek -n " . expand("%:p"))
+  let metrics = system("reek " . expand("%:p"))
   let loclist = []
 
   if g:reek_debug


### PR DESCRIPTION
`reek -n` supresses line numbering on reek versions of 1.3.4 and above,
causing the location list for smells remain empty.

Commit in reek repository that breaks the vim-reek https://github.com/troessner/reek/commit/a4fb58e43651dfb618ffa6a3eb8553d23c574668
