### PR TITLE
FIx bug empty location list

### DIFF
--- a/plugin/reek.vim
+++ b/plugin/reek.vim
@@ -32,7 +32,7 @@ function! s:Reek()
   endif
 
   for line in split(metrics, '\n')
-    let err = matchlist(line, '\v\s+\[(.*)\]:(.*)')
+    let err = matchlist(line, '\v\s*\[(.*)\]:(.*)')
     if strlen(get(err, 2)) > 1
       for lnum in split(err[1], ', ')
         call add(loclist, { 'bufnr': bufnr('%'), 'lnum': lnum, 'text': err[2] })


### PR DESCRIPTION
The regex is giving empty result which causes the location list to be empty.
I think this should resolve the issue.
